### PR TITLE
Fix: Populate applicant details in getApplicationsForJob

### DIFF
--- a/backend/controllers/applicationController.js
+++ b/backend/controllers/applicationController.js
@@ -47,10 +47,10 @@ exports.shortlistCandidate = async (req, res) => {
 
 exports.getApplicationsForJob = async (req, res) => {
   try {
-    const applications = await Application.find({ job: req.params.jobId }).populate(
-      'applicant',
-      'firstName lastName email'
-    );
+    const applications = await Application.find({ job: req.params.jobId }).populate({
+      path: 'applicant',
+      select: 'firstName lastName email',
+    });
     res.json(applications);
   } catch (error) {
     res.status(500).json({ message: error.message });


### PR DESCRIPTION
This commit fixes a bug where applicant details were not being correctly populated when fetching job applications.

The `populate` call in the `getApplicationsForJob` function in `applicationController.js` has been updated to use the object syntax. This ensures that the `applicant` field is correctly populated with the `firstName`, `lastName`, and `email` from the `User` collection.