### PR TITLE
Fix: Ensure employers can see job applicants

### DIFF
--- a/backend/controllers/applicationController.js
+++ b/backend/controllers/applicationController.js
@@ -49,6 +49,7 @@ exports.getApplicationsForJob = async (req, res) => {
   try {
     const applications = await Application.find({ job: req.params.jobId }).populate({
       path: 'applicant',
+      model: 'User',
       select: 'firstName lastName email',
     });
     res.json(applications);

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "mocha --exit"
+    "test": "mocha --timeout 10000 --exit"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/backend/test/application.test.js
+++ b/backend/test/application.test.js
@@ -1,0 +1,81 @@
+const request = require('supertest');
+const { expect } = require('chai');
+const app = require('../app');
+const { setup, teardown, clearDatabase } = require('./test-setup');
+const Employer = require('../models/employerModel');
+const Job = require('../models/jobModel');
+const User = require('../models/userModel');
+const Application = require('../models/applicationModel');
+const jwt = require('jsonwebtoken');
+
+describe('Application Routes', () => {
+  let employer;
+  let user;
+  let job;
+  let employerToken;
+  let userToken;
+
+  before(async () => {
+    await setup();
+    await clearDatabase();
+
+    // Create a new employer
+    employer = new Employer({
+      companyName: 'Test Corp',
+      email: 'employer@test.com',
+      password: 'password123',
+    });
+    await employer.save();
+    employerToken = jwt.sign({ _id: employer._id, userType: 'employer' }, "MySuperSecretKey123!@#$%^&*()_+=123");
+
+    // Create a new user
+    user = new User({
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'user@test.com',
+      password: 'password123',
+    });
+    await user.save();
+    userToken = jwt.sign({ _id: user._id, userType: 'user' }, "MySuperSecretKey123!@#$%^&*()_+=123");
+
+    // Create a new job
+    job = new Job({
+      title: 'Software Engineer',
+      description: 'A great job',
+      company: 'Test Corp',
+      candidate_required_location: 'Remote',
+      job_type: 'Full-time',
+      employer: employer._id,
+    });
+    await job.save();
+  });
+
+  after(async () => {
+    await teardown();
+  });
+
+  afterEach(async () => {
+    await clearDatabase();
+  });
+
+  describe('GET /api/applications/job/:jobId', () => {
+    it('should return all applications for a job with applicant details', async () => {
+      // Create an application
+      const application = new Application({
+        job: job._id,
+        applicant: user._id,
+      });
+      await application.save();
+
+      const res = await request(app)
+        .get(`/api/applications/job/${job._id}`)
+        .set('Authorization', `Bearer ${employerToken}`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('array').with.lengthOf(1);
+      expect(res.body[0].applicant).to.have.property('firstName', 'John');
+      expect(res.body[0].applicant).to.have.property('lastName', 'Doe');
+      expect(res.body[0].applicant).to.have.property('email', 'user@test.com');
+    });
+  });
+});


### PR DESCRIPTION
The `getApplicationsForJob` function in `applicationController.js` was not correctly populating the `applicant` field. This was because the `model` was not explicitly specified in the `.populate()` call.

This commit fixes the bug by adding `model: 'User'` to the `.populate()` call, ensuring that the applicant's details are correctly fetched and sent to the frontend.

A new test case has been added to verify the fix and prevent future regressions.