### PR TITLE
Fix: Correct JWT payload for employer login

### DIFF
--- a/backend/controllers/employerController.js
+++ b/backend/controllers/employerController.js
@@ -54,7 +54,7 @@ const loginEmployer = async (req, res) => {
   try {
     const employer = await Employer.findOne({ email });
     if (employer && await bcrypt.compare(password, employer.password)) {
-      const token = jwt.sign({ _id: employer._id, email: employer.email, type: 'employer' }, JWT_SECRET, { expiresIn: "1h" });
+      const token = jwt.sign({ _id: employer._id, email: employer.email, userType: 'employer' }, JWT_SECRET, { expiresIn: "1h" });
       res.json({
         token,
         user: { _id: employer._id, name: employer.companyName, email: employer.email }


### PR DESCRIPTION
A previous commit introduced a regression that prevented employers from accessing their own job postings. This was due to an inconsistency between the JWT payload generated at login and the check performed in the `isEmployer` middleware.

This commit fixes the regression by changing the JWT payload to use `userType: 'employer'` instead of `type: 'employer'`, aligning it with the middleware.