### PR TITLE
fix: Correct CORS configuration to allow Authorization header

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -24,7 +24,8 @@ const app = express();
 
 app.use(cors({
   origin: 'http://localhost:3000',
-  methods: ['GET', 'POST', 'DELETE'],
+  methods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Authorization', 'Content-Type'],
   credentials: true,
 }));
 


### PR DESCRIPTION
This commit fixes the final bug that was preventing the notification system from working.

The root cause was a server-side CORS (Cross-Origin Resource Sharing) misconfiguration. The backend was not explicitly configured to allow the `Authorization` header in requests from the frontend. This caused the browser to block the `GET /api/chat/notifications` request after a successful preflight (`OPTIONS`) request, meaning the notification data was never fetched.

This fix updates the CORS middleware in `backend/app.js` to explicitly include `Authorization` in the `allowedHeaders`. This resolves the issue and allows the frontend to securely communicate with the backend to fetch notifications.