### PR TITLE
chore: Add frontend logging for auth token debugging

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -26,6 +26,7 @@ export const fetchJobs = async (searchTerm = '', locations = [], jobTypes = []) 
 };
 
 export const getNotifications = async (token) => {
+  console.log('[getNotifications] Using token:', token);
   try {
     const response = await fetch(`${API_URL}/chat/notifications`, {
       headers: {


### PR DESCRIPTION
This commit adds a console log to the `getNotifications` API call on the frontend.

To help diagnose an `Authentication token required` error, this change will print the authentication token to the browser console immediately before the request is made. This will help verify whether the token is correctly being passed from the `ChatContext` to the API service.