### PR TITLE
fix: Correct data type mismatch in notification query

### DIFF
--- a/backend/services/notificationService.js
+++ b/backend/services/notificationService.js
@@ -16,7 +16,7 @@ const getNotificationsForUser = async (userId) => {
       {
         $match: {
           'messages.read': false,
-          'messages.user': { $ne: userId },
+          'messages.user': { $ne: userId.toString() },
         },
       },
       // Group by sender and count unread messages


### PR DESCRIPTION
This commit fixes the root cause of the bug where notifications were not being found in the database.

The issue was a data type mismatch in the MongoDB aggregation pipeline within the `notificationService`. The query was comparing the user's `_id` (an ObjectId) with the `messages.user` field (a String). This comparison would always fail, resulting in an empty list of notifications.

This fix resolves the issue by converting the `userId` to a string within the query (`userId.toString()`). This ensures the data types match, allowing the query to correctly identify and return unread messages.