### PR TITLE
fix: Resolve data type mismatch in notification lookup

### DIFF
--- a/backend/services/notificationService.js
+++ b/backend/services/notificationService.js
@@ -1,4 +1,5 @@
 const Chat = require('../models/chatModel');
+const mongoose = require('mongoose');
 
 const getNotificationsForUser = async (userId) => {
   try {
@@ -28,11 +29,17 @@ const getNotificationsForUser = async (userId) => {
           lastMessage: { $last: '$messages.text' },
         },
       },
+      // Convert the string _id to ObjectId for lookup
+      {
+        $addFields: {
+          senderIdObj: { $toObjectId: '$_id' }
+        }
+      },
       // Get sender's information from the Users collection
       {
         $lookup: {
           from: 'Users',
-          localField: '_id',
+          localField: 'senderIdObj', // Use the new ObjectId field for joining
           foreignField: '_id',
           as: 'senderInfo',
         },


### PR DESCRIPTION
This commit fixes the definitive root cause of the bug where notifications were not being found in the database, even though unread messages existed.

The issue was a data type mismatch in the `$lookup` stage of the MongoDB aggregation pipeline. The `_id` field, which represented the sender's ID, was a string after the `$group` stage. However, the `_id` field in the `Users` collection is an `ObjectId`. The `$lookup` stage was failing because a string will never match an ObjectId.

This fix resolves the issue by adding an `$addFields` stage to the pipeline. This new stage uses the `$toObjectId` operator to convert the string-based `senderId` into a proper `ObjectId` before the `$lookup` is performed. This ensures the join succeeds and the sender's information can be correctly retrieved, allowing the notification query to return the correct results.