### PR TITLE
fix: Prevent notifications for chats without a job link

### DIFF
--- a/backend/services/notificationService.js
+++ b/backend/services/notificationService.js
@@ -31,6 +31,8 @@ const getNotificationsForUser = async (userId) => {
           jobId: { $first: '$jobId' },
         },
       },
+      // Filter out any notifications that don't have a jobId (from old chats)
+      { $match: { jobId: { $exists: true, $ne: null } } },
       // Convert string _id to ObjectId for lookups
       {
         $addFields: {


### PR DESCRIPTION
This commit fixes a critical bug where clicking a notification for an older chat would lead to an "Invalid job ID" error.

The root cause was that chat documents created before the `jobId` field was introduced were still generating notifications. These notifications lacked a `jobId`, causing the frontend navigation to fail when they were clicked.

This fix resolves the issue by adding a `$match` stage to the `notificationService` aggregation pipeline. This stage filters out any potential notifications that do not have a valid `jobId`, ensuring that only well-formed, clickable notifications are ever sent to the user.

This makes the system more robust and prevents errors caused by legacy data.