### PR TITLE
feat: Implement role-based, intelligent navigation for notifications

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -72,14 +72,14 @@ const Navbar = () => {
   const handleCancelLogout = () => setShowConfirm(false);
 
   const handleNotificationClick = (notification) => {
-    // Set the chat that should be opened after the page navigates.
     setPendingChat(notification);
 
     // Navigate to the correct page based on the user's role.
     if (userType === 'employer') {
       navigate('/posted-jobs');
     } else {
-      navigate('/applied-jobs');
+      // For job seekers, navigate directly to the job details page.
+      navigate(`/jobs/${notification.jobId}`);
     }
 
     setIsNotificationOpen(false);

--- a/frontend/src/pages/JobDetails.jsx
+++ b/frontend/src/pages/JobDetails.jsx
@@ -22,10 +22,23 @@ const JobDetails = () => {
   const [notification, setNotification] = useState({ message: '', type: '' });
   const [showConfirm, setShowConfirm] = useState(false);
   const [confirmAction, setConfirmAction] = useState(null);
-  const { joinRoom } = useContext(ChatContext);
+  const { joinRoom, pendingChat, clearPendingChat } = useContext(ChatContext);
   const { token } = useContext(AuthContext);
 
   const [applied, setApplied] = useState(false);
+
+  // Effect to handle opening a chat from a notification
+  useEffect(() => {
+    if (job && pendingChat && pendingChat.jobId === job._id) {
+      joinRoom(
+        pendingChat.senderId,
+        pendingChat.senderName,
+        pendingChat.jobId,
+        pendingChat.jobTitle
+      );
+      clearPendingChat();
+    }
+  }, [job, pendingChat, joinRoom, clearPendingChat]);
 
   const handleApply = async () => {
     try {


### PR DESCRIPTION
This commit implements a major user experience enhancement by creating a more intelligent and role-specific navigation flow when a user clicks on a chat notification.

The new workflow is as follows:
- **For Job Seekers:** Clicking a notification from an employer now navigates them directly to the relevant **Job Details page**, where the chat window with that employer automatically opens.
- **For Employers:** Clicking a notification from a job seeker now navigates them to their **Posted Jobs page**. The page then automatically expands the applicant list for the relevant job and opens the chat window with that applicant.

This is achieved through a new "pending chat" system:
1.  The `ChatContext` is updated with a `pendingChat` state and functions to manage it.
2.  The `Navbar` now sets this `pendingChat` state and navigates the user to the correct destination page based on their role.
3.  The `JobDetails` and `PostedJobs` pages are now context-aware. They use a `useEffect` hook to listen for the `pendingChat` state and, if it matches their context, they automatically open the chat window and perform any necessary UI actions (like expanding an accordion).

This creates a seamless, one-click experience that takes the user directly to the most relevant context for the conversation, significantly improving the application's usability.