### PR TITLE
chore: Add diagnostic logging to track missing jobId

### DIFF
--- a/frontend/src/context/ChatContext.js
+++ b/frontend/src/context/ChatContext.js
@@ -104,6 +104,7 @@ const ChatProvider = ({ children }) => {
         jobId: currentJobId,
         timestamp: new Date(),
       };
+      console.log('[ChatContext] Emitting sendMessage with data:', messageData); // Diagnostic log
       setMessages((prev) => ({
         ...prev,
         [activeRoom]: [...(prev[activeRoom] || []), messageData],


### PR DESCRIPTION
This commit adds a `console.log` to the `sendMessage` function in the `ChatContext` on the frontend.

A `Chat validation failed: jobId: Path 'jobId' is required` error on the backend indicates that the `jobId` is not being sent when a new chat is initiated. This diagnostic log will print the entire `messageData` object to the browser console immediately before it is emitted via the socket.

This will allow for precise verification of the data being sent from the client and help identify why the `jobId` is missing from the payload.