### PR TITLE
feat: Allow guest users to view jobs

### DIFF
--- a/frontend/src/pages/JobDetails.jsx
+++ b/frontend/src/pages/JobDetails.jsx
@@ -147,8 +147,6 @@ const JobDetails = () => {
         <p className="text-red-500 dark:text-red-400">{error}</p>
         <Link
           to="/home"
-          to="/home"
-          to="/home"
           className="text-blue-600 hover:underline text-sm mt-4 inline-block dark:text-blue-200 dark:hover:text-blue-100"
           aria-label="Back to home"
         >
@@ -163,8 +161,7 @@ const JobDetails = () => {
       <div className="p-4 max-w-3xl mx-auto text-center">
         <p className="text-gray-500 dark:text-gray-200">Job not found.</p>
         <Link
-          to="/"
-          onClick={handleHomeClick}
+          to="/home"
           className="text-blue-600 hover:underline text-sm mt-4 inline-block dark:text-blue-200 dark:hover:text-blue-100"
           aria-label="Back to home"
         >
@@ -178,8 +175,7 @@ const JobDetails = () => {
     <div className="p-4 max-w-3xl mx-auto relative">
       <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-lg dark:shadow-gray-800/50">
         <Link
-          to="/"
-          onClick={handleHomeClick}
+          to="/home"
           className="text-blue-600 hover:underline text-sm dark:text-blue-200 dark:hover:text-blue-100 mb-4 inline-block"
           aria-label="Back to home"
         >


### PR DESCRIPTION
This change implements a guest-accessible job seeker flow.

Key changes:
- Unauthenticated users can now browse the job listings (`/home`) and view job details (`/jobs/:id`).
- The 'Login' and 'Signup' navigation links are hidden on the user type selection page and on the login/signup pages themselves.
- If a guest attempts to save or apply for a job, they are redirected to the login page.