### PR TITLE
fix: Resolve employer update failure and improve validation UX

### DIFF
--- a/backend/controllers/employerController.js
+++ b/backend/controllers/employerController.js
@@ -21,18 +21,20 @@ const updateEmployerProfile = async (req, res) => {
     const employer = await Employer.findById(req.user._id);
 
     if (employer) {
-      employer.companyName = req.body.companyName || employer.companyName;
-
       // Prevent email updates
       if (req.body.email && req.body.email !== employer.email) {
         return res.status(400).json({ message: 'Email address cannot be changed.' });
       }
 
-      // Allow clearing optional fields by checking if the property exists in the body
-      if (req.body.hasOwnProperty('companyDescription')) {
+      // Update fields if they are present in the request. The `in` operator is used
+      // for safety as req.body from multer may not have hasOwnProperty.
+      if ('companyName' in req.body) {
+        employer.companyName = req.body.companyName;
+      }
+      if ('companyDescription' in req.body) {
         employer.companyDescription = req.body.companyDescription;
       }
-      if (req.body.hasOwnProperty('website')) {
+      if ('website' in req.body) {
         employer.website = req.body.website;
       }
 

--- a/frontend/src/pages/EmployerProfilePage.js
+++ b/frontend/src/pages/EmployerProfilePage.js
@@ -66,7 +66,6 @@ const EmployerProfilePage = () => {
   const handleUpdate = async (e) => {
     e.preventDefault();
     if (!validate()) {
-      toast.error('Please fix the errors before submitting.');
       return;
     }
     const formData = new FormData();

--- a/frontend/src/pages/UserProfilePage.js
+++ b/frontend/src/pages/UserProfilePage.js
@@ -82,7 +82,6 @@ const UserProfilePage = () => {
   const handleUpdate = async (e) => {
     e.preventDefault();
     if (!validate()) {
-      toast.error('Please fix the errors before submitting.');
       return;
     }
     try {


### PR DESCRIPTION
- **Fix:** Corrects a critical regression in the employer profile page that prevented any updates. The issue was caused by using an unsafe `hasOwnProperty` check on `req.body` after `multer` processing. Replaced it with the safer `in` operator to reliably handle `FormData`.
- **Chore:** Improves the validation user experience on both the job seeker and employer profile pages by removing the generic `toast.error` message. This change ensures that only the specific, inline error messages are shown, preventing redundant notifications as requested.