### PR TITLE
fix: Enforce suspension on login and improve admin UI

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -74,6 +74,9 @@ const loginUser = async (req, res) => {
   try {
     const user = await userService.findUserForLogin(email);
     if (user && (await bcrypt.compare(password, user.password))) {
+      if (!user.isActive) {
+        return res.status(403).json({ message: "Your account has been suspended. Please contact support." });
+      }
       const token = jwt.sign({ _id: user._id, email: user.email, type: 'user', isAdmin: user.isAdmin }, JWT_SECRET, { expiresIn: "1h" });
       res.json({
         token,

--- a/backend/controllers/employerController.js
+++ b/backend/controllers/employerController.js
@@ -112,6 +112,9 @@ const loginEmployer = async (req, res) => {
   try {
     const employer = await Employer.findOne({ email });
     if (employer && await bcrypt.compare(password, employer.password)) {
+      if (!employer.isActive) {
+        return res.status(403).json({ message: "Your account has been suspended. Please contact support." });
+      }
       const token = jwt.sign({ _id: employer._id, email: employer.email, type: 'employer' }, JWT_SECRET, { expiresIn: "1h" });
       res.json({
         token,

--- a/frontend/src/pages/AdminDashboard.js
+++ b/frontend/src/pages/AdminDashboard.js
@@ -205,7 +205,7 @@ const UserManagement = ({ users, setUsers }) => {
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Name</th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Email</th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Suspend</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Active</th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Make Admin</th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Actions</th>
               </tr>
@@ -316,7 +316,7 @@ const UserManagement = ({ users, setUsers }) => {
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Company Name</th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Email</th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Suspend</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Active</th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Actions</th>
               </tr>
             </thead>


### PR DESCRIPTION
This commit addresses two critical issues:

1.  **Security Fix:** Suspended users and employers are now correctly blocked from logging into their accounts. The backend login logic for both `authController` and `employerController` has been updated to check the `isActive` flag before issuing an authentication token.

2.  **UX Improvement:** The column header in the Admin Dashboard for suspending users/employers has been renamed from "Suspend" to "Active". This clarifies the meaning of the toggle switch, where ON now intuitively means the account is active.