### PR TITLE
fix(admin): Resolve tooltip and navigation issues

### DIFF
--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -242,7 +242,7 @@ const UserManagement = ({ users, setUsers, fetchUsers }) => {
             </thead>
             <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
               {users.map((user) => (
-                <tr key={user._id} className="relative z-0">
+                <tr key={user._id}>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100 truncate">
                     <Tooltip text={`${user.firstName} ${user.lastName}`}>
                       <span>{user.firstName} {user.lastName}</span>
@@ -396,7 +396,7 @@ const EmployerManagement = ({ employers, setEmployers, fetchEmployers }) => {
                     </thead>
                     <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
                         {employers.map((employer) => (
-                            <tr key={employer._id} className="relative z-0">
+                            <tr key={employer._id}>
                                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100 truncate">
                                     <Tooltip text={employer.companyName}>
                                         <span>{employer.companyName}</span>

--- a/frontend/src/pages/AdminEditJobPage.jsx
+++ b/frontend/src/pages/AdminEditJobPage.jsx
@@ -34,7 +34,7 @@ const AdminEditJobPage = () => {
       const token = sessionStorage.getItem('token');
       await updateJob(jobId, job, token);
       toast.success('Job updated successfully.');
-      navigate(-1); // Go back to the previous page
+      navigate(`/admin/employer/${job.employer._id}/jobs`);
     } catch (error) {
       toast.error('Failed to update job.');
     }


### PR DESCRIPTION
This commit addresses two issues in the admin module:

1.  The tooltip on the admin dashboard's user and employer tables was not consistently appearing on top of other elements. This was caused by a z-index conflict, which has been resolved by removing the `relative` and `z-0` classes from the table rows.

2.  After an admin updated an employer's job, they were not redirected to the correct page. This has been fixed by updating the navigation logic to redirect to the employer's "Manage Jobs" page.