### PR TITLE
fix(admin): Resolve tooltip and navigation issues

### DIFF
--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -242,16 +242,20 @@ const UserManagement = ({ users, setUsers, fetchUsers }) => {
             </thead>
             <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
               {users.map((user) => (
-                <tr key={user._id} className="relative z-0">
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100 truncate">
-                    <Tooltip text={`${user.firstName} ${user.lastName}`}>
-                      <span>{user.firstName} {user.lastName}</span>
-                    </Tooltip>
+                <tr key={user._id}>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100 truncate overflow-visible">
+                    <div className="group relative">
+                      <Tooltip text={`${user.firstName} ${user.lastName}`}>
+                        <span>{user.firstName} {user.lastName}</span>
+                      </Tooltip>
+                    </div>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300 truncate">
-                    <Tooltip text={user.email}>
-                      <span>{user.email}</span>
-                    </Tooltip>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300 truncate overflow-visible">
+                    <div className="group relative">
+                      <Tooltip text={user.email}>
+                        <span>{user.email}</span>
+                      </Tooltip>
+                    </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <ToggleSwitch enabled={user.isActive} onChange={() => handleToggleStatus(user)} />
@@ -396,16 +400,20 @@ const EmployerManagement = ({ employers, setEmployers, fetchEmployers }) => {
                     </thead>
                     <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
                         {employers.map((employer) => (
-                            <tr key={employer._id} className="relative z-0">
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100 truncate">
-                                    <Tooltip text={employer.companyName}>
-                                        <span>{employer.companyName}</span>
-                                    </Tooltip>
+                            <tr key={employer._id}>
+                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100 truncate overflow-visible">
+                                    <div className="group relative">
+                                        <Tooltip text={employer.companyName}>
+                                            <span>{employer.companyName}</span>
+                                        </Tooltip>
+                                    </div>
                                 </td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300 truncate">
-                                    <Tooltip text={employer.email}>
-                                        <span>{employer.email}</span>
-                                    </Tooltip>
+                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300 truncate overflow-visible">
+                                    <div className="group relative">
+                                        <Tooltip text={employer.email}>
+                                            <span>{employer.email}</span>
+                                        </Tooltip>
+                                    </div>
                                 </td>
                                 <td className="px-6 py-4 whitespace-nowrap">
                                     <ToggleSwitch enabled={employer.isActive} onChange={() => handleToggleStatus(employer)} />

--- a/frontend/src/pages/AdminEditJobPage.jsx
+++ b/frontend/src/pages/AdminEditJobPage.jsx
@@ -32,9 +32,9 @@ const AdminEditJobPage = () => {
     e.preventDefault();
     try {
       const token = sessionStorage.getItem('token');
-      await updateJob(jobId, job, token);
+      const updatedJob = await updateJob(jobId, job, token);
       toast.success('Job updated successfully.');
-      navigate(-1); // Go back to the previous page
+      navigate(`/admin/employer/${job.employer._id}/jobs`);
     } catch (error) {
       toast.error('Failed to update job.');
     }


### PR DESCRIPTION
This commit addresses two issues in the admin module:

1.  The tooltip on the admin dashboard's user and employer tables was not consistently appearing on top of other elements. This was caused by the hover state not being correctly propagated to the Tooltip component. This has been resolved by wrapping the tooltip's trigger element in a div with the `group` class.

2.  After an admin updated an employer's job, they were not redirected to the correct page. This has been fixed by using the correct employer ID from the `job` object to construct the navigation URL.