### PR TITLE
fix(admin): Resolve tooltip clipping and navigation issues

### DIFF
--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -243,14 +243,14 @@ const UserManagement = ({ users, setUsers, fetchUsers }) => {
             <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
               {users.map((user) => (
                 <tr key={user._id} className="relative z-0">
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100 truncate">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
                     <Tooltip text={`${user.firstName} ${user.lastName}`}>
-                      <span>{user.firstName} {user.lastName}</span>
+                      <span className="truncate">{user.firstName} {user.lastName}</span>
                     </Tooltip>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300 truncate">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
                     <Tooltip text={user.email}>
-                      <span>{user.email}</span>
+                      <span className="truncate">{user.email}</span>
                     </Tooltip>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
@@ -397,14 +397,14 @@ const EmployerManagement = ({ employers, setEmployers, fetchEmployers }) => {
                     <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
                         {employers.map((employer) => (
                             <tr key={employer._id} className="relative z-0">
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100 truncate">
+                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
                                     <Tooltip text={employer.companyName}>
-                                        <span>{employer.companyName}</span>
+                                        <span className="truncate">{employer.companyName}</span>
                                     </Tooltip>
                                 </td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300 truncate">
+                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
                                     <Tooltip text={employer.email}>
-                                        <span>{employer.email}</span>
+                                        <span className="truncate">{employer.email}</span>
                                     </Tooltip>
                                 </td>
                                 <td className="px-6 py-4 whitespace-nowrap">

--- a/frontend/src/pages/AdminEditJobPage.jsx
+++ b/frontend/src/pages/AdminEditJobPage.jsx
@@ -34,7 +34,7 @@ const AdminEditJobPage = () => {
       const token = sessionStorage.getItem('token');
       await updateJob(jobId, job, token);
       toast.success('Job updated successfully.');
-      navigate(-1); // Go back to the previous page
+      navigate(`/admin/employer/${job.employer._id}/jobs`);
     } catch (error) {
       toast.error('Failed to update job.');
     }

--- a/frontend_output.log
+++ b/frontend_output.log
@@ -1,0 +1,3 @@
+
+> hunt-career@0.1.0 start
+> react-scripts start


### PR DESCRIPTION
This commit addresses two long-standing issues in the admin module:

1.  **Tooltip Clipping:** Tooltips on truncated text in the admin dashboard tables were being clipped by the parent table cell. This was because the `truncate` class was on the `<td>` element itself, preventing any of its children from overflowing. The fix moves the `truncate` class from the `<td>` to the `<span>` that directly wraps the text, allowing the tooltip to render correctly.

2.  **Incorrect Navigation:** After an admin updated a job, the redirection to the employer's job list was failing. The logic has been corrected to use the `job.employer._id` from the component's state to construct the proper URL, ensuring a successful redirect.