### PR TITLE
Fix: Correct Route Order for Saved Jobs

### DIFF
--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -22,11 +22,12 @@ router.put('/profile/:id', authenticateToken, ensureDb, updateUserProfile);
 router.put('/profile', authenticateToken, ensureDb, isJobSeeker, updateUserProfile);
 router.get('/applications', authenticateToken, ensureDb, getUserApplications);
 router.get('/applied-jobs', authenticateToken, ensureDb, getAppliedJobs);
-router.get('/:id', authenticateToken, ensureDb, getUserById);
 
 // Saved Jobs
 router.get('/saved-jobs', authenticateToken, ensureDb, isJobSeeker, getSavedJobs);
 router.post('/saved-jobs/:jobId', authenticateToken, ensureDb, isJobSeeker, saveJob);
 router.delete('/saved-jobs/:jobId', authenticateToken, ensureDb, isJobSeeker, unsaveJob);
+
+router.get('/:id', authenticateToken, ensureDb, getUserById);
 
 module.exports = router;


### PR DESCRIPTION
This commit fixes a runtime error that was caused by incorrect route ordering in `backend/routes/userRoutes.js`. The generic `/:id` route was being matched before the more specific `/saved-jobs` route, which caused the "Failed to fetch saved jobs" error.

This commit reorders the routes to ensure that the `/saved-jobs` route is matched first, which resolves the issue.

This also includes the initial implementation of the user-specific saved jobs feature.