### PR TITLE
Fix job posting regex error and user identification issues

### DIFF
--- a/backend/controllers/employerController.js
+++ b/backend/controllers/employerController.js
@@ -136,7 +136,7 @@ const loginEmployer = async (req, res) => {
         token,
         employer: {
           _id: employer._id,
-          name: `${employer.firstName} ${employer.lastName}`,
+          name: (employer.firstName && employer.lastName) ? `${employer.firstName} ${employer.lastName}` : employer.companyName,
           companyName: employer.companyName,
           companyId: employer.company,
           role: employer.role,

--- a/backend/controllers/jobController.js
+++ b/backend/controllers/jobController.js
@@ -63,8 +63,8 @@ const createJob = async (req, res) => {
     const escapedCompany = escapeRegex(company);
 
     const existingJob = await Job.findOne({
-      title: { $regex: new RegExp(`^${escapedTitle}$`, 'i') },
-      company: { $regex: new RegExp(`^${escapedCompany}$`, 'i') },
+      title: { $regex: `^${escapedTitle}$`, $options: 'i' },
+      company: { $regex: `^${escapedCompany}$`, $options: 'i' },
       employer: req.user._id,
     });
 
@@ -73,6 +73,9 @@ const createJob = async (req, res) => {
     }
 
     const employer = await Employer.findById(req.user._id);
+    if (!employer) {
+      return res.status(404).json({ message: 'Employer not found' });
+    }
     const newJob = new Job({
       ...req.body,
       employer: req.user._id,
@@ -188,8 +191,8 @@ const updateJob = async (req, res) => {
     const escapedTitle = escapeRegex(title);
     const escapedCompany = escapeRegex(company);
     const existingJob = await Job.findOne({
-      title: { $regex: new RegExp(`^${escapedTitle}$`, 'i') },
-      company: { $regex: new RegExp(`^${escapedCompany}$`, 'i') },
+      title: { $regex: `^${escapedTitle}$`, $options: 'i' },
+      company: { $regex: `^${escapedCompany}$`, $options: 'i' },
       employer: req.user._id,
       _id: { $ne: id },
     });

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -29,12 +29,14 @@ const Navbar = () => {
 
   useEffect(() => {
     if (isAuthenticated && user) {
-      const name = user.name || user.companyName || '';
-      const nameParts = name.split(' ');
-      const initials =
-        nameParts.length > 1
-          ? `${nameParts[0][0]}${nameParts[1][0]}`
-          : name.slice(0, 2).toUpperCase() || 'U';
+      const name = user.name || user.companyName || 'User';
+      const nameParts = name.trim().split(/\s+/);
+      let initials = 'U';
+      if (nameParts.length >= 2) {
+        initials = `${nameParts[0][0]}${nameParts[1][0]}`.toUpperCase();
+      } else if (nameParts.length === 1 && nameParts[0].length > 0) {
+        initials = nameParts[0].slice(0, 2).toUpperCase();
+      }
       setUserInitials(initials);
     }
   }, [isAuthenticated, user]);


### PR DESCRIPTION
- Corrected MongoDB '$regex' syntax in 'jobController.js' to use string patterns instead of 'RegExp' objects, resolving the "Can't use $regex" error.
- Fixed user identity issue where initials were not correctly generated; added fallback for name in 'employerController.js' and robust initials logic in 'Navbar.jsx'.
- Added safety check in 'createJob' to prevent crashes when employer data is missing.
- Refined initials generation to always be uppercase and handle various name formats.