### PR TITLE
Fix field collision in Job model by renaming company reference to com…

### DIFF
--- a/backend/controllers/employerController.js
+++ b/backend/controllers/employerController.js
@@ -156,7 +156,7 @@ const loginEmployer = async (req, res) => {
 const getEmployerApplications = async (req, res) => {
   try {
     const employer = await Employer.findById(req.user._id);
-    const jobs = await Job.find({ company: employer.company });
+    const jobs = await Job.find({ companyId: employer.company });
     const jobIds = jobs.map(job => job._id);
     const applications = await Application.find({ job: { $in: jobIds } });
     res.json(applications);
@@ -168,7 +168,7 @@ const getEmployerApplications = async (req, res) => {
 const getApplicationsOverTime = async (req, res) => {
   try {
     const employer = await Employer.findById(req.user._id);
-    const jobs = await Job.find({ company: employer.company });
+    const jobs = await Job.find({ companyId: employer.company });
     const jobIds = jobs.map(job => job._id);
     const applications = await Application.find({ job: { $in: jobIds } });
     const data = applications.reduce((acc, app) => {
@@ -186,7 +186,7 @@ const getApplicationsOverTime = async (req, res) => {
 const getJobPostingsSummary = async (req, res) => {
   try {
     const employer = await Employer.findById(req.user._id);
-    const jobs = await Job.find({ company: employer.company });
+    const jobs = await Job.find({ companyId: employer.company });
     const data = jobs.reduce((acc, job) => {
       if (job.job_type) {
         acc[job.job_type] = (acc[job.job_type] || 0) + 1;
@@ -203,7 +203,7 @@ const getJobPostingsSummary = async (req, res) => {
 const getRecentActivity = async (req, res) => {
   try {
     const employer = await Employer.findById(req.user._id);
-    const jobs = await Job.find({ company: employer.company });
+    const jobs = await Job.find({ companyId: employer.company });
     const jobIds = jobs.map(job => job._id);
     const applications = await Application.find({ job: { $in: jobIds } })
       .sort({ date: -1 })
@@ -253,7 +253,7 @@ const getEmployerDashboardMetrics = async (req, res) => {
     const companyId = employer.company;
 
     const metrics = await Job.aggregate([
-      { $match: { company: companyId } },
+      { $match: { companyId: companyId } },
       {
         $lookup: {
           from: 'applications',
@@ -310,7 +310,7 @@ const getEmployerDashboardMetrics = async (req, res) => {
     // Fallback for case-sensitive collections if standard ones are empty
     if (metrics[0].jobMetrics.length === 0) {
        const altMetrics = await mongoose.connection.db.collection('Jobs').aggregate([
-        { $match: { company: companyId } },
+        { $match: { companyId: companyId } },
         {
           $lookup: {
             from: 'Applications',

--- a/backend/controllers/jobController.js
+++ b/backend/controllers/jobController.js
@@ -80,7 +80,7 @@ const createJob = async (req, res) => {
     const newJob = new Job({
       ...req.body,
       employer: req.user._id,
-      company: employer.company,
+      companyId: employer.company,
     });
     const savedJob = await newJob.save();
     await Employer.findByIdAndUpdate(req.user._id, { $push: { postedJobs: savedJob._id } });
@@ -99,7 +99,7 @@ const getEmployerJobs = async (req, res) => {
     }
 
     // Find all jobs for the company, not just the individual recruiter
-    const jobs = await Job.find({ company: employer.company, status: { $ne: 'Archived' } });
+    const jobs = await Job.find({ companyId: employer.company, status: { $ne: 'Archived' } });
     res.json(jobs);
   } catch (error) {
     res.status(500).json({ message: error.message });

--- a/backend/models/jobModel.js
+++ b/backend/models/jobModel.js
@@ -8,7 +8,7 @@ const jobSchema = new mongoose.Schema({
   job_type: { type: String, required: true },
   status: { type: String, enum: ['Open', 'Closed', 'Draft', 'Archived'], default: 'Open' },
   employer: { type: mongoose.Schema.Types.ObjectId, ref: 'Employer', required: true },
-  company: { type: mongoose.Schema.Types.ObjectId, ref: 'Company' },
+  companyId: { type: mongoose.Schema.Types.ObjectId, ref: 'Company' },
 }, {
   timestamps: true,
 });


### PR DESCRIPTION
…panyId

- Renamed the 'company' ObjectId reference field in 'jobModel.js' to 'companyId' to avoid conflict with the existing 'company' string field.
- Updated 'jobController.js' and 'employerController.js' to use the new 'companyId' field for queries and aggregations.
- Resolved "Cast to ObjectId failed" error when posting or searching for jobs.