### PR TITLE
Revert job listing and dashboard metrics to individual employer scope

### DIFF
--- a/backend/controllers/employerController.js
+++ b/backend/controllers/employerController.js
@@ -155,8 +155,7 @@ const loginEmployer = async (req, res) => {
 
 const getEmployerApplications = async (req, res) => {
   try {
-    const employer = await Employer.findById(req.user._id);
-    const jobs = await Job.find({ companyId: employer.company });
+    const jobs = await Job.find({ employer: req.user._id });
     const jobIds = jobs.map(job => job._id);
     const applications = await Application.find({ job: { $in: jobIds } });
     res.json(applications);
@@ -167,8 +166,7 @@ const getEmployerApplications = async (req, res) => {
 
 const getApplicationsOverTime = async (req, res) => {
   try {
-    const employer = await Employer.findById(req.user._id);
-    const jobs = await Job.find({ companyId: employer.company });
+    const jobs = await Job.find({ employer: req.user._id });
     const jobIds = jobs.map(job => job._id);
     const applications = await Application.find({ job: { $in: jobIds } });
     const data = applications.reduce((acc, app) => {
@@ -185,8 +183,7 @@ const getApplicationsOverTime = async (req, res) => {
 
 const getJobPostingsSummary = async (req, res) => {
   try {
-    const employer = await Employer.findById(req.user._id);
-    const jobs = await Job.find({ companyId: employer.company });
+    const jobs = await Job.find({ employer: req.user._id });
     const data = jobs.reduce((acc, job) => {
       if (job.job_type) {
         acc[job.job_type] = (acc[job.job_type] || 0) + 1;
@@ -202,8 +199,7 @@ const getJobPostingsSummary = async (req, res) => {
 
 const getRecentActivity = async (req, res) => {
   try {
-    const employer = await Employer.findById(req.user._id);
-    const jobs = await Job.find({ companyId: employer.company });
+    const jobs = await Job.find({ employer: req.user._id });
     const jobIds = jobs.map(job => job._id);
     const applications = await Application.find({ job: { $in: jobIds } })
       .sort({ date: -1 })
@@ -249,11 +245,10 @@ const updateEmployerTheme = async (req, res) => {
 
 const getEmployerDashboardMetrics = async (req, res) => {
   try {
-    const employer = await Employer.findById(req.user._id);
-    const companyId = employer.company;
+    const employerId = new mongoose.Types.ObjectId(req.user._id);
 
     const metrics = await Job.aggregate([
-      { $match: { companyId: companyId } },
+      { $match: { employer: employerId } },
       {
         $lookup: {
           from: 'applications',
@@ -310,7 +305,7 @@ const getEmployerDashboardMetrics = async (req, res) => {
     // Fallback for case-sensitive collections if standard ones are empty
     if (metrics[0].jobMetrics.length === 0) {
        const altMetrics = await mongoose.connection.db.collection('Jobs').aggregate([
-        { $match: { companyId: companyId } },
+        { $match: { employer: employerId } },
         {
           $lookup: {
             from: 'Applications',

--- a/backend/controllers/jobController.js
+++ b/backend/controllers/jobController.js
@@ -98,8 +98,8 @@ const getEmployerJobs = async (req, res) => {
       return res.status(404).json({ message: "Employer not found." });
     }
 
-    // Find all jobs for the company, not just the individual recruiter
-    const jobs = await Job.find({ companyId: employer.company, status: { $ne: 'Archived' } });
+    // Find only jobs posted by this specific recruiter
+    const jobs = await Job.find({ employer: req.user._id, status: { $ne: 'Archived' } });
     res.json(jobs);
   } catch (error) {
     res.status(500).json({ message: error.message });


### PR DESCRIPTION
- Updated 'getEmployerJobs', 'getEmployerApplications', and dashboard metric aggregations to filter by individual 'employer' ID instead of 'companyId'.
- Ensures recruiters only see and manage jobs they personally posted, resolving the issue where all company jobs appeared in a single user's view.
- Maintains 'companyId' field in models for future organization-wide reporting features.